### PR TITLE
FieldIO refactor

### DIFF
--- a/doc/source/Developing.rst
+++ b/doc/source/Developing.rst
@@ -147,14 +147,16 @@ There are generally two types of merger-tree data that ytree
 ingests:
 
 1. all merger-tree data (full trees, halos, etc.) contained within
-a single file.  An example of this is the consistent-trees frontend.
+a single file.  An example of this is the ``consistent-trees`` frontend.
 
 2. halos in files grouped by redshift (halo catalogs) that contain
 the halo id for the descendent halo which lives in the next catalog.
-An example of this is the rockstar frontend.
+An example of this is the ``rockstar`` frontend.
 
 Depending on your case, different base classes should be subclassed.
-This is discussed below.
+This is discussed below. There are also hybrid formats that use
+both merger-tree and halo catalog files together. An example of this
+is the ``ahf`` (Amiga Halo Finder) frontend.
 
 The ``_is_valid`` Function
 ##########################

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -66,8 +66,7 @@ Internal Classes
    ~ytree.arbor.fields.FakeFieldContainer
    ~ytree.arbor.io.FieldIO
    ~ytree.arbor.io.TreeFieldIO
-   ~ytree.arbor.io.RootFieldIO
-   ~ytree.arbor.io.FallbackRootFieldIO
+   ~ytree.arbor.io.DefaultRootFieldIO
    ~ytree.arbor.io.DataFile
    ~ytree.arbor.io.CatalogDataFile
    ~ytree.arbor.tree_node.TreeNode

--- a/tests/test_ytree_1x.py
+++ b/tests/test_ytree_1x.py
@@ -15,6 +15,8 @@ tests for backward compatibility with ytree 1.x
 
 import glob
 import h5py
+from numpy.testing import \
+    assert_array_equal
 import os
 from ytree.utilities.testing import \
     assert_array_rel_equal, \
@@ -65,6 +67,28 @@ class YTree1xTest(TempDirTest):
             compare_hdf5(basename, filename,
                          compare=assert_array_rel_equal,
                          decimals=15)
+
+    @requires_file(ytree_1x_data)
+    def test_1x_root_fields(self):
+        results_filenames = \
+          glob.glob(os.path.join(test_data_dir,
+                                 "ytree_1x/results/*.h5"))
+
+        fields = ["uid", "redshift"]
+        for filename in results_filenames:
+            basename = os.path.basename(filename)
+            arbor_filename = \
+              os.path.join(test_data_dir, "ytree_1x/arbors",
+                           "arbor_%s" % basename)
+            if "tree_farm" in filename:
+                tfields = fields + ["particle_mass"]
+            else:
+                tfields = fields + ["mvir"]
+
+            a = ytree.load(arbor_filename)
+            for field in tfields:
+                my_data = a.arr([t[field] for t in a])
+                assert_array_equal(my_data, a[field])
 
     @requires_file(ytree_1x_data)
     def test_1x_tree_farms(self):

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -871,7 +871,7 @@ class Arbor(object):
             for field, fieldname in zip(fields, fieldnames):
                 for di, node in enumerate(my_nodes):
                     if node.is_root:
-                        ndata = node._tree_field_data[field]
+                        ndata = node._field_data[field]
                     else:
                         ndata = node["tree", field]
                         if field == "desc_uid":
@@ -1006,8 +1006,8 @@ class CatalogArbor(Arbor):
         # This should bypass any attempt to get this field in
         # the conventional way.
         if self.field_info["uid"]["source"] == "arbor":
-            tree_node._tree_field_data["uid"] = tree_node._uids
-            tree_node._tree_field_data["desc_uid"] = tree_node._descids
+            tree_node._field_data["uid"] = tree_node._uids
+            tree_node._field_data["desc_uid"] = tree_node._descids
 
     def _grow_tree(self, tree_node):
         pass

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -45,7 +45,7 @@ from ytree.arbor.fields import \
 from ytree.arbor.misc import \
     _determine_output_filename
 from ytree.arbor.io import \
-    FallbackRootFieldIO, \
+    DefaultRootFieldIO, \
     TreeFieldIO
 from ytree.arbor.tree_node import \
     TreeNode
@@ -86,7 +86,7 @@ class Arbor(object):
     """
 
     _field_info_class = FieldInfoContainer
-    _root_field_io_class = FallbackRootFieldIO
+    _root_field_io_class = DefaultRootFieldIO
     _tree_field_io_class = TreeFieldIO
 
     def __init__(self, filename):

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -98,7 +98,7 @@ class Arbor(object):
         self.basename = os.path.basename(filename)
         self._parse_parameter_file()
         self._set_units()
-        self._root_field_data = FieldContainer(self)
+        self._field_data = FieldContainer(self)
         self._node_io = self._tree_field_io_class(self)
         self._root_io = self._root_field_io_class(self)
         self._get_data_files()
@@ -310,8 +310,8 @@ class Arbor(object):
                 raise SyntaxError("Argument must be a field or integer.")
             self._root_io.get_fields(self, fields=[key])
             if self.field_info[key].get("type") == "analysis":
-                return self._root_field_data.pop(key)
-            return self._root_field_data[key]
+                return self._field_data.pop(key)
+            return self._field_data[key]
         return self.trees[key]
 
     def __len__(self):
@@ -829,7 +829,7 @@ class Arbor(object):
                    for key in ["units", "description"]
                    if key in fi)
             if all_trees:
-                rdata[fieldname] = self._root_field_data[field]
+                rdata[fieldname] = self._field_data[field]
             else:
                 rdata[fieldname] = self.arr([t[field] for t in trees])
             rtypes[fieldname] = "data"

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -128,9 +128,10 @@ class Arbor(object):
     def is_setup(self, tree_node):
         """
         Return True if arrays of uids and descendent uids have
-        been read in.
+        been read in. Setup has also completed if tree is already
+        grown.
         """
-        return tree_node.root != -1 or \
+        return self.is_grown(tree_node) or \
           tree_node._uids is not None
 
     def _setup_tree(self, tree_node, **kwargs):
@@ -158,7 +159,7 @@ class Arbor(object):
         Return True if a tree has been fully assembled, i.e.,
         the hierarchy of ancestor tree nodes has been built.
         """
-        return hasattr(tree_node, "treeid")
+        return tree_node.root != -1
 
     def _grow_tree(self, tree_node, **kwargs):
         """
@@ -303,7 +304,6 @@ class Arbor(object):
         If given a string, return an array of field values for the
         roots of all trees.
         If given an integer, return a tree from the list of trees.
-
         """
         if isinstance(key, string_types):
             if key in ("tree", "prog"):
@@ -791,7 +791,8 @@ class Arbor(object):
 
         self._node_io_loop(self._setup_tree, root_nodes=roots,
                            pbar="Setting up trees")
-        self._root_io.get_fields(self, fields=fields)
+        if all_trees:
+            self._root_io.get_fields(self, fields=fields)
 
         # determine file layout
         nn = 0 # node count
@@ -955,10 +956,6 @@ class CatalogArbor(Arbor):
                     batch[it] = tree_node
                     if root:
                         trees.append(tree_node)
-                        if self.field_info["uid"]["source"] == "arbor":
-                            tree_node._root_field_data["uid"] = \
-                              tree_node.uid
-                            tree_node._root_field_data["desc_uid"] = -1
                     else:
                         ancs[descid].append(tree_node)
                     uid += 1
@@ -1014,9 +1011,6 @@ class CatalogArbor(Arbor):
 
     def _grow_tree(self, tree_node):
         pass
-
-    def is_grown(self, tree_node):
-        return True
 
 
 global load_warn

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -218,12 +218,18 @@ class Arbor(object):
             If None, the list will be self.trees (i.e., all
             root_nodes).
             Default: None.
+        store : optional, string
+            If not None, any return value captured from the function
+            will be stored in an attribute with this name associated
+            with the TreeNode.
+            Default: None.
         """
 
         pbar = kwargs.pop("pbar", None)
         root_nodes = kwargs.pop("root_nodes", None)
         if root_nodes is None:
             root_nodes = self.trees
+        store = kwargs.pop("store", None)
         data_files, node_list = self._node_io_loop_prepare(root_nodes)
         nnodes = sum([nodes.size for nodes in node_list])
 
@@ -238,7 +244,9 @@ class Arbor(object):
         for data_file, nodes in zip(data_files, node_list):
             self._node_io_loop_start(data_file)
             for node in nodes:
-                func(node, *args, **kwargs)
+                rval = func(node, *args, **kwargs)
+                if store is not None:
+                    setattr(node, store, rval)
                 pbar.update(1)
             self._node_io_loop_finish(data_file)
 

--- a/ytree/arbor/frontends/arborarbor/arbor.py
+++ b/ytree/arbor/frontends/arborarbor/arbor.py
@@ -80,7 +80,8 @@ class ArborArbor(Arbor):
         treeids = fh["data"]["tree_id"].value.astype(np.int64)
         fh.close()
 
-        roots = uids[descids == -1]
+        root_filter = descids == -1
+        roots = uids[root_filter]
         ntrees = roots.size
         self._trees = np.empty(ntrees, dtype=np.object)
         for i, root in enumerate(roots):
@@ -91,7 +92,7 @@ class ArborArbor(Arbor):
         self._field_cache = {}
         self._field_cache["uid"] = uids
         self._field_cache["desc_id"] = descids
-        self._ri = roots
+        self._ri = np.where(root_filter)[0]
 
     def _setup_tree(self, tree_node):
         # skip if this is not a root or if already setup
@@ -99,8 +100,8 @@ class ArborArbor(Arbor):
             return
 
         ifield = tree_node._fi
-        tree_node._uids    = self._field_cache["uid"][ifield]
-        tree_node._descids = self._field_cache["desc_id"][ifield]
+        tree_node._uids      = self._field_cache["uid"][ifield]
+        tree_node._desc_uids = self._field_cache["desc_id"][ifield]
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/ytree/arbor/frontends/arborarbor/io.py
+++ b/ytree/arbor/frontends/arborarbor/io.py
@@ -69,7 +69,7 @@ class ArborArborRootFieldIO(RootFieldIO):
             dtypes = {}
         self.arbor.trees
 
-        fcache = storage_object._root_field_data
+        fcache = storage_object._field_data
 
         fh = h5py.File(self.arbor.filename, "r")
         field_data = {}

--- a/ytree/arbor/frontends/arborarbor/io.py
+++ b/ytree/arbor/frontends/arborarbor/io.py
@@ -16,7 +16,7 @@ ArborArbor io classes and member functions
 import h5py
 
 from ytree.arbor.io import \
-    RootFieldIO, \
+    FieldIO, \
     TreeFieldIO
 
 class ArborArborTreeFieldIO(TreeFieldIO):
@@ -63,7 +63,7 @@ class ArborArborTreeFieldIO(TreeFieldIO):
 
         return field_data
 
-class ArborArborRootFieldIO(RootFieldIO):
+class ArborArborRootFieldIO(FieldIO):
     def _read_fields(self, storage_object, fields, dtypes=None):
         if dtypes is None:
             dtypes = {}

--- a/ytree/arbor/frontends/lhalotree/io.py
+++ b/ytree/arbor/frontends/lhalotree/io.py
@@ -16,7 +16,8 @@ LHaloTreeArbor io classes and member functions
 import numpy as np
 # import weakref
 from ytree.arbor.io import \
-    TreeFieldIO, RootFieldIO
+    FieldIO, \
+    TreeFieldIO
 
 
 # class LHaloTreeFileID(object):
@@ -121,7 +122,7 @@ class LHaloTreeTreeFieldIO(TreeFieldIO):
         return field_data
 
 
-class LHaloTreeRootFieldIO(RootFieldIO):
+class LHaloTreeRootFieldIO(FieldIO):
     def _read_fields(self, storage_object, fields, dtypes=None):
         r"""Add root fields in bulk to same time."""
         if dtypes is None:

--- a/ytree/arbor/frontends/rockstar/arbor.py
+++ b/ytree/arbor/frontends/rockstar/arbor.py
@@ -91,7 +91,7 @@ class RockstarArbor(CatalogArbor):
 
         # the scale factor comes from the catalog file header
         fields.append("scale_factor")
-        fi["scale_factor"] = {"column": "header", "units": ""}
+        fi["scale_factor"] = {"source": "header", "units": ""}
 
         self.field_list = fields
         self.field_info.update(fi)

--- a/ytree/arbor/frontends/ytree/io.py
+++ b/ytree/arbor/frontends/ytree/io.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ytree.arbor.io import \
     DataFile, \
-    RootFieldIO, \
+    FieldIO, \
     TreeFieldIO
 
 class YTreeDataFile(DataFile):
@@ -76,7 +76,7 @@ class YTreeTreeFieldIO(TreeFieldIO):
 
         return field_data
 
-class YTreeRootFieldIO(RootFieldIO):
+class YTreeRootFieldIO(FieldIO):
     def _read_fields(self, storage_object, fields, dtypes=None):
         if dtypes is None:
             dtypes = {}

--- a/ytree/arbor/frontends/ytree/io.py
+++ b/ytree/arbor/frontends/ytree/io.py
@@ -100,13 +100,13 @@ class YTreeRootFieldIO(RootFieldIO):
     def _initialize_analysis_field(self, storage_object,
                                    name, units, **kwargs):
         # Always refresh this because it may have changed.
-        if name in storage_object._root_field_data:
-            data = storage_object._root_field_data[name]
+        if name in storage_object._field_data:
+            data = storage_object._field_data[name]
         else:
             data = np.zeros(storage_object.size)
             if units != "":
                 data = self.arbor.arr(data, units)
-            storage_object._root_field_data[name] = data
+            storage_object._field_data[name] = data
 
         for i, halo in enumerate(storage_object):
             data[i] = halo[name]

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -44,7 +44,7 @@ class FieldIO(object):
         """
         Figure out which objects are responsible for storing field data.
         """
-        return data_object, data_object._field_data
+        return data_object
 
     def _read_fields(self, *args, **kwargs):
         """
@@ -65,7 +65,7 @@ class FieldIO(object):
         Load field data for a data object into storage structures.
         """
 
-        if fields is None or len(fields) == 0:
+        if not fields:
             return
 
         # hack to make sure root_only is False if this is not a root
@@ -73,8 +73,9 @@ class FieldIO(object):
           not data_object.is_root:
             kwargs["root_only"] = False
 
-        storage_object, fcache = \
+        storage_object = \
           self._determine_field_storage(data_object, **kwargs)
+        fcache = storage_object._field_data
 
         fi = self.arbor.field_info
 
@@ -151,8 +152,7 @@ class TreeFieldIO(FieldIO):
             storage_object = data_object
         else:
             storage_object = data_object.root
-        fcache = storage_object._field_data
-        return storage_object, fcache
+        return storage_object
 
     def _read_fields(self, root_node, fields, dtypes=None,
                      root_only=False):
@@ -205,7 +205,7 @@ class DefaultRootFieldIO(FieldIO):
     """
 
     def get_fields(self, data_object, fields=None):
-        if fields is None or len(fields) == 0:
+        if not fields:
             return
 
         fi = self.arbor.field_info

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -126,7 +126,7 @@ class FieldIO(object):
                 if ftype == "alias":
                     data = fcache[fi[field]["dependencies"][0]]
                 elif ftype == "derived":
-                    data = fi[field]["function"](fcache)
+                    data = fi[field]["function"](fi[field], fcache)
                 if hasattr(data, "units") and units is not None:
                     data.convert_to_units(units)
                 fcache[field] = data

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -136,26 +136,26 @@ class TreeFieldIO(FieldIO):
 
     def _initialize_analysis_field(self, storage_object,
                                    name, units, **kwargs):
-        if name in storage_object._tree_field_data:
+        if name in storage_object._field_data:
             return
         storage_object.arbor._setup_tree(storage_object)
         data = np.zeros(storage_object.uids.size)
         if units != "":
             data = self.arbor.arr(data, units)
-        storage_object._tree_field_data[name] = data
+        storage_object._field_data[name] = data
 
     def _determine_field_storage(self, data_object, **kwargs):
         if data_object.is_root:
             storage_object = data_object
         else:
             storage_object = data_object.root
-        fcache = storage_object._tree_field_data
+        fcache = storage_object._field_data
 
         return storage_object, fcache
 
     def _store_fields(self, storage_object, field_data, **kwargs):
         if not field_data: return
-        storage_object._tree_field_data.update(field_data)
+        storage_object._field_data.update(field_data)
 
     def _read_fields(self, root_node, fields, dtypes=None,
                      root_only=False):
@@ -245,7 +245,7 @@ class FallbackRootFieldIO(FieldIO):
                   self.arbor.arr(field_data[field], units)
             for i in range(self.arbor.trees.size):
                 field_data[field][i] = \
-                  self.arbor.trees[i]._tree_field_data[field][0]
+                  self.arbor.trees[i]._field_data[field][0]
         data_object._field_data.update(field_data)
 
 class DataFile(object):

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -207,10 +207,10 @@ class RootFieldIO(FieldIO):
     """
 
     def _determine_field_storage(self, data_object, **kwargs):
-        return data_object, data_object._root_field_data
+        return data_object, data_object._field_data
 
     def _store_fields(self, storage_object, field_data, **kwargs):
-        storage_object._root_field_data.update(field_data)
+        storage_object._field_data.update(field_data)
 
 class FallbackRootFieldIO(FieldIO):
     """
@@ -226,7 +226,7 @@ class FallbackRootFieldIO(FieldIO):
 
         fields_to_get = []
         for field in fields:
-            if field not in data_object._root_field_data:
+            if field not in data_object._field_data:
                 fields_to_get.append(field)
         if not fields_to_get:
             return
@@ -246,7 +246,7 @@ class FallbackRootFieldIO(FieldIO):
             for i in range(self.arbor.trees.size):
                 field_data[field][i] = \
                   self.arbor.trees[i]._tree_field_data[field][0]
-        data_object._root_field_data.update(field_data)
+        data_object._field_data.update(field_data)
 
 class DataFile(object):
     """

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -44,7 +44,7 @@ class FieldIO(object):
         """
         Figure out which objects are responsible for storing field data.
         """
-        raise NotImplementedError
+        return data_object, data_object._field_data
 
     def _read_fields(self, *args, **kwargs):
         """
@@ -56,7 +56,9 @@ class FieldIO(object):
         """
         Store the field data in the proper place.
         """
-        raise NotImplementedError
+        if not field_data:
+            return
+        storage_object._field_data.update(field_data)
 
     def get_fields(self, data_object, fields=None, **kwargs):
         """
@@ -150,12 +152,7 @@ class TreeFieldIO(FieldIO):
         else:
             storage_object = data_object.root
         fcache = storage_object._field_data
-
         return storage_object, fcache
-
-    def _store_fields(self, storage_object, field_data, **kwargs):
-        if not field_data: return
-        storage_object._field_data.update(field_data)
 
     def _read_fields(self, root_node, fields, dtypes=None,
                      root_only=False):
@@ -201,18 +198,7 @@ class TreeFieldIO(FieldIO):
 
         return field_data
 
-class RootFieldIO(FieldIO):
-    """
-    IO class for getting fields for the roots of all trees.
-    """
-
-    def _determine_field_storage(self, data_object, **kwargs):
-        return data_object, data_object._field_data
-
-    def _store_fields(self, storage_object, field_data, **kwargs):
-        storage_object._field_data.update(field_data)
-
-class FallbackRootFieldIO(FieldIO):
+class DefaultRootFieldIO(FieldIO):
     """
     Class for getting root fields from arbors that have no
     specialized storage for root fields.
@@ -246,7 +232,7 @@ class FallbackRootFieldIO(FieldIO):
             for i in range(self.arbor.trees.size):
                 field_data[field][i] = \
                   self.arbor.trees[i]._field_data[field][0]
-        data_object._field_data.update(field_data)
+        self._store_fields(data_object, field_data)
 
 class DataFile(object):
     """

--- a/ytree/arbor/tree_node.py
+++ b/ytree/arbor/tree_node.py
@@ -192,10 +192,6 @@ class TreeNode(object):
                 raise SyntaxError(
                     "Must be either 1 or 2 arguments.")
             ftype, field = key
-            if ftype == "line":
-                raise SyntaxError(
-                    "\"line\" has been deprecated. " +
-                    "Please use \"prog\" instead.")
             if ftype not in arr_types:
                 raise SyntaxError(
                     "First argument must be one of %s." % str(arr_types))
@@ -212,10 +208,6 @@ class TreeNode(object):
         else:
             if isinstance(key, string_types):
                 # return the progenitor list or tree nodes in a list
-                if key == "line":
-                    raise SyntaxError(
-                        "\"line\" has been deprecated. " +
-                        "Please use \"prog\" instead.")
                 if key in arr_types:
                     self.arbor._setup_tree(self)
                     return getattr(self, "_%s_nodes" % key)

--- a/ytree/arbor/tree_node.py
+++ b/ytree/arbor/tree_node.py
@@ -42,7 +42,7 @@ class TreeNode(object):
         if root:
             self.root = -1
             self.treeid = 0
-            self._tree_field_data = FieldContainer(arbor)
+            self._field_data = FieldContainer(arbor)
         else:
             self.root = None
 
@@ -58,7 +58,7 @@ class TreeNode(object):
 
         if not self.is_root:
             return
-        self._tree_field_data.clear()
+        self._field_data.clear()
 
     def reset(self):
         """
@@ -139,7 +139,7 @@ class TreeNode(object):
             treeid = self.treeid
         self.arbor._node_io.get_fields(self, fields=[key],
                                        root_only=False)
-        data = root._tree_field_data[key]
+        data = root._field_data[key]
         data[treeid] = value
 
     def __getitem__(self, key):
@@ -199,7 +199,7 @@ class TreeNode(object):
 
             self.arbor._node_io.get_fields(self, fields=[field], root_only=False)
             indices = getattr(self, "_%s_field_indices" % ftype)
-            return self.root._tree_field_data[field][indices]
+            return self.root._field_data[field][indices]
 
         else:
             if not isinstance(key, string_types):
@@ -217,7 +217,7 @@ class TreeNode(object):
                 data_object = self
             else:
                 data_object = self.root
-            return data_object._tree_field_data[key][self.treeid]
+            return data_object._field_data[key][self.treeid]
 
     def __repr__(self):
         return "TreeNode[%d]" % self.uid

--- a/ytree/arbor/tree_node.py
+++ b/ytree/arbor/tree_node.py
@@ -69,7 +69,7 @@ class TreeNode(object):
         attrs = ["_tfi", "_tn", "_pfi", "_pn"]
         if self.is_root:
             self.root = -1
-            attrs.extend(["_nodes", "_descids", "_uids"])
+            attrs.extend(["_nodes", "_desc_uids", "_uids"])
         else:
             self.root = None
         for attr in attrs:
@@ -104,14 +104,14 @@ class TreeNode(object):
             self.arbor._setup_tree(self)
         return self._uids
 
-    _descids = None
+    _desc_uids = None
     @property
-    def descids(self):
+    def desc_uids(self):
         if not self.is_root:
             return None
-        if self._descids is None:
+        if self._desc_uids is None:
             self.arbor._setup_tree(self)
-        return self._descids
+        return self._desc_uids
 
     _tree_size = None
     @property

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -97,6 +97,24 @@ class ArborTest(object):
     def test_save_and_reload(self):
         save_and_compare(self.arbor, skip=self.tree_skip)
 
+    def test_vector_fields(self):
+        a = self.arbor
+        t = a[0]
+        for field in a.field_info.vector_fields:
+            for i, ax in enumerate("xyz"):
+                assert_array_equal(
+                    a["%s_%s" % (field, ax)],
+                    a[field][:, i])
+
+                assert_array_equal(
+                    t["%s_%s" % (field, ax)],
+                    t[field][i])
+
+                for group in ["prog", "tree"]:
+                    assert_array_equal(
+                        t[group, "%s_%s" % (field, ax)],
+                        t[group, field][:, i])
+
 def save_and_compare(arbor, skip=1):
     """
     Check that arbor saves correctly.

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -14,6 +14,7 @@ testing utilities
 #-----------------------------------------------------------------------------
 
 import h5py
+import numpy as np
 from numpy.testing import \
     assert_array_equal
 import os
@@ -101,6 +102,10 @@ class ArborTest(object):
         a = self.arbor
         t = a[0]
         for field in a.field_info.vector_fields:
+
+            magfield = np.sqrt((a[field]**2).sum(axis=1))
+            assert_array_equal(a["%s_magnitude" % field], magfield)
+
             for i, ax in enumerate("xyz"):
                 assert_array_equal(
                     a["%s_%s" % (field, ax)],


### PR DESCRIPTION
This is a refactor of the FieldIO system that removes 1 of the 3 active `FieldContainer` objects and renames the other two to allow for additional simplification. As an added bonus, we no longer store the dependencies of a given field when it is queried, thus reducing memory.

This also add vector fields, which was my original point for doing this.