### PR TITLE
Only suppress yt logging for yt.load

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -5,7 +5,7 @@
 ytree is licensed under the terms of the Modified BSD License
 (also known as New or Revised BSD), as follows:
 
-Copyright (c) 2015-, Britton Smith
+Copyright (c) 2015-, ytree development team
 
 All rights reserved.
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,7 +6,7 @@ miscellaneous utility tests
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2016-2017, Britton Smith <brittonsmith@gmail.com>
+# Copyright (c) ytree development team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_select_halos.py
+++ b/tests/test_select_halos.py
@@ -6,7 +6,7 @@ miscellaneous utility tests
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2016-2017, Britton Smith <brittonsmith@gmail.com>
+# Copyright (c) ytree development team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -1110,7 +1110,7 @@ def load(filename, method=None, **kwargs):
                           (method, arbor_registry.keys()))
 
     global load_warn
-    if method != "YTree" and load_warn:
+    if method not in ["YTree", "LHaloTree"] and load_warn:
         print(
             ("Performance will be improved by saving this arbor with " +
              "\"save_arbor\" and reloading:\n" +

--- a/ytree/tree_farm/tree_farm.py
+++ b/ytree/tree_farm/tree_farm.py
@@ -16,8 +16,6 @@ TreeFarm class and member functions
 import numpy as np
 import os
 
-from yt.convenience import \
-    load as yt_load
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
 from yt.funcs import \
@@ -40,6 +38,8 @@ from ytree.tree_farm.ancestry_short import \
 from ytree.tree_farm.halo_selector import \
     selector_registry, \
     clear_id_cache
+from ytree.utilities.io import \
+    yt_load
 from ytree.utilities.logger import \
     set_parallel_logger, \
     ytreeLogger as mylog

--- a/ytree/utilities/exceptions.py
+++ b/ytree/utilities/exceptions.py
@@ -6,7 +6,7 @@ ytree exceptions
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2017, Britton Smith <brittonsmith@gmail.com>
+# Copyright (c) ytree development team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/ytree/utilities/io.py
+++ b/ytree/utilities/io.py
@@ -14,9 +14,14 @@ io utilities
 #-----------------------------------------------------------------------------
 
 import numpy as np
+
+from yt.convenience import \
+    load as _yt_load
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity
+from yt.utilities.logger import \
+    ytLogger
 
 def parse_h5_attr(f, attr):
     """A Python3-safe function for getting hdf5 attributes.
@@ -99,3 +104,16 @@ def f_text_block(f, block_size=32768, file_size=None, sep="\n"):
     if lbuff:
         loc = f.tell() - len(lbuff)
         yield lbuff, loc
+
+def yt_load(filename, **kwargs):
+    """
+    Suppress logging for yt.load, but return to original setting.
+
+    This allows yt.load to show logs in scripts, but not in ytree.
+    """
+    level = ytLogger.level
+    if level > 10 and level < 40:
+        ytLogger.setLevel(40)
+    ds = _yt_load(filename, **kwargs)
+    ytLogger.setLevel(level)
+    return ds

--- a/ytree/utilities/logger.py
+++ b/ytree/utilities/logger.py
@@ -6,7 +6,7 @@ ytree logger
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2016, Britton Smith <brittonsmith@gmail.com>
+# Copyright (c) ytree development team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -15,11 +15,6 @@ ytree logger
 
 import logging
 import sys
-
-from yt.utilities.logger import \
-    ytLogger
-
-ytLogger.setLevel(40)
 
 # CRITICAL 50
 # ERROR    40


### PR DESCRIPTION
This changes the blanket suppression of yt logging to one that suppresses during `yt.load` and then returns to the originally value so that logging is not suppressed in scripts. I also updated a couple copyrights and remove LHaloTree from the list of frontends that would benefit from saving and reloading because it's pretty dang fast already.