### PR TITLE
Move creation of old_fields list until after tree might be setup.

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,13 +14,16 @@ miscellaneous utility tests
 #-----------------------------------------------------------------------------
 
 import os
+from ytree.arbor.arbor import \
+    load as ytree_load
 from ytree.utilities.io import \
     f_text_block
 from ytree.utilities.testing import \
     requires_file, \
     test_data_dir
 
-R63 = os.path.join(test_data_dir, "rockstar_halos/out_63.list")
+R0 = os.path.join(test_data_dir, "rockstar/rockstar_halos/out_0.list")
+R63 = os.path.join(test_data_dir, "rockstar/rockstar_halos/out_63.list")
 
 @requires_file(R63)
 def test_f_text_block():
@@ -40,3 +43,15 @@ def test_f_text_block():
 
         for l1, l2 in zip(lines, lines2):
             assert l1 == l2
+
+@requires_file(R0)
+def test_tree_field_clobber():
+    """
+    Test for an issue where the uid and desc_uid fields would be
+    deleted if the tree was setup in the middle of getting fields.
+    Fixed in PR #19: https://github.com/brittonsmith/ytree/pull/19
+    """
+    a = ytree_load(R0)
+    t = a[a['mass'].argmax()]
+    t['prog', 'redshift']
+    t.save_tree()

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -77,7 +77,6 @@ class FieldIO(object):
         storage_object = \
           self._determine_field_storage(data_object)
         fcache = storage_object._field_data
-        old_fields = list(fcache.keys())
 
         fi = self.arbor.field_info
 
@@ -97,6 +96,11 @@ class FieldIO(object):
         fields_to_read, fields_to_generate = \
           fi.resolve_field_dependencies(fields, fcache=fcache,
                                         fsize=fsize)
+
+        # Keep list of fields present before getting new ones.
+        # We need to do this after trees have been setup since
+        # that will add fields to the field cache in some cases.
+        old_fields = list(fcache.keys())
 
         # Read in fields we need that are on disk.
         if fields_to_read:


### PR DESCRIPTION
## PR Summary

This fixes an issue with rockstar data. The following script would produce an error:
```
import ytree
a = ytree.load("rockstar_halos/out_0.list")
t = a[a['mass'].argmax()]
t['prog', 'redshift']
t.save_tree()
```

The call to `t['prog', 'redshift']` would clobber the `uid` and `desc_uid` fields because the list of fields to save would be created before the tree would be setup.

## PR Checklist

- [ ] Code passes tests.
- [ ] Tests added for fixed bugs or new features.