### PR TITLE
[bugfix] fix field access on catalog arbors when tree not setup

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,6 +20,7 @@ from ytree.utilities.io import \
     f_text_block
 from ytree.utilities.testing import \
     requires_file, \
+    TempDirTest, \
     test_data_dir
 
 R0 = os.path.join(test_data_dir, "rockstar/rockstar_halos/out_0.list")
@@ -44,14 +45,30 @@ def test_f_text_block():
         for l1, l2 in zip(lines, lines2):
             assert l1 == l2
 
-@requires_file(R0)
-def test_tree_field_clobber():
+class MiscTest(TempDirTest):
     """
-    Test for an issue where the uid and desc_uid fields would be
-    deleted if the tree was setup in the middle of getting fields.
-    Fixed in PR #19: https://github.com/brittonsmith/ytree/pull/19
+    Some miscellaneous tests in temporary directories
+    """
+
+    @requires_file(R0)
+    def test_tree_field_clobber(self):
+        """
+        Test for an issue where the uid and desc_uid fields would be
+        deleted if the tree was setup in the middle of getting fields.
+        Fixed in PR #19: https://github.com/brittonsmith/ytree/pull/19
+        """
+        a = ytree_load(R0)
+        t = a[a['mass'].argmax()]
+        t['prog', 'redshift']
+        t.save_tree()
+
+@requires_file(R0)
+def test_field_access_without_tree_setup():
+    """
+    Test field access on non-root nodes of catalog arbors where
+    setup_tree has not been called.
+    Fixed in PR #20: https://github.com/brittonsmith/ytree/pull/20
     """
     a = ytree_load(R0)
     t = a[a['mass'].argmax()]
-    t['prog', 'redshift']
-    t.save_tree()
+    t.ancestors[0]['desc_uid']

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -89,7 +89,7 @@ class FieldIO(object):
             if data_object.is_root:
                 root = data_object
             else:
-                root = data_object.root
+                root = data_object.find_root()
             fsize = root.tree_size
 
         # Resolve field dependencies.
@@ -155,11 +155,7 @@ class TreeFieldIO(FieldIO):
         storage_object._field_data[name] = data
 
     def _determine_field_storage(self, data_object):
-        if data_object.is_root:
-            storage_object = data_object
-        else:
-            storage_object = data_object.root
-        return storage_object
+        return data_object.find_root()
 
     def _read_fields(self, root_node, fields, dtypes=None,
                      root_only=False):

--- a/ytree/arbor/tree_node.py
+++ b/ytree/arbor/tree_node.py
@@ -51,6 +51,17 @@ class TreeNode(object):
     def is_root(self):
         return self.root in [-1, self]
 
+    def find_root(self):
+        """
+        Find the root node.
+        """
+        my_node = self
+        while not my_node.is_root:
+            if my_node.descendent == -1:
+                break
+            my_node = my_node.descendent
+        return my_node
+
     def clear_fields(self):
         """
         If a root node, delete field data.


### PR DESCRIPTION
## PR Summary

This fixes an issue where field access fails on non-root nodes of trees that have not been setup.

This will fail:
```
import ytree
a = ytree.load("rockstar/rockstar_halos/out_0.list")
t = a[a['mass'].argmax()]
f = t.ancestors[0]['desc_uid']
```

## PR Checklist

- [x] Code passes tests.
- [x] Tests added for fixed bugs or new features.