### PR TITLE
[bugfix] Restore arbor access to analysis fields

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,56 @@
+"""
+tests for analysis fields
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) ytree development team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+from numpy.testing import \
+    assert_array_equal
+import os
+
+from ytree.utilities.testing import \
+    requires_file, \
+    test_data_dir, \
+    TempDirTest
+
+import ytree
+
+CT = os.path.join(test_data_dir,
+                  "consistent_trees/tree_0_0_0.dat")
+
+class AnalysisFieldTest(TempDirTest):
+    @requires_file(CT)
+    def test_analysis_fields(self):
+        a = ytree.load(CT)
+
+        a.add_analysis_field('bears', 'Msun/yr')
+
+        fake_bears = np.zeros(a.size)
+        assert_array_equal(fake_bears, a['bears'])
+
+        a[0]['bears'] = 9
+        fake_bears[0] = 9
+        assert_array_equal(fake_bears, a['bears'])
+
+        fake_tree_bears = np.zeros(a[1].tree_size)
+        assert_array_equal(
+            fake_tree_bears, a[1]['tree', 'bears'])
+        fake_tree_bears[72] = 99
+        a[1]['tree'][72]['bears'] = 99
+        assert_array_equal(fake_tree_bears, a[1]['tree', 'bears'])
+
+        fn = a.save_arbor()
+        a2 = ytree.load(fn)
+
+        assert_array_equal(fake_bears, a2['bears'])
+        assert_array_equal(fake_tree_bears, a2[1]['tree', 'bears'])

--- a/ytree/arbor/io.py
+++ b/ytree/arbor/io.py
@@ -207,6 +207,17 @@ class DefaultRootFieldIO(FieldIO):
     specialized storage for root fields.
     """
 
+    def _initialize_analysis_field(self, storage_object,
+                                   name, units, **kwargs):
+        data = np.zeros(storage_object.size)
+        if units != "":
+            data = self.arbor.arr(data, units)
+        for i, t in enumerate(storage_object):
+            if name not in t._field_data:
+                continue
+            data[i] = t[name]
+        storage_object._field_data[name] = data
+
     def _read_fields(self, storage_object, fields, dtypes=None,
                      root_only=True):
         if not fields:


### PR DESCRIPTION
## PR Summary

Accessing analysis fields for the root of all trees was broken as it was not implemented for the field i/o refactor leading up to ytree 2.2. The following would break:

```
import ytree
a = ytree.load("consistent_trees/tree_0_0_0.dat")
a.add_analysis_fields('bears', 'Msun/yr')
a['bears']
```

## PR Checklist

- [ ] Code passes tests.
- [x] Tests added for fixed bugs or new features.